### PR TITLE
Nakedblinder w/o CConfidential Asset

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -17,13 +17,6 @@ void CConfidentialAsset::SetToAsset(const CAsset& asset)
     vchCommitment.insert(vchCommitment.end(), asset.begin(), asset.end());
 }
 
-void CConfidentialAsset::SetToBlinder(const uint256& blinder)
-{
-    vchCommitment.reserve(nCommittedSize);
-    vchCommitment.push_back(12);
-    vchCommitment.insert(vchCommitment.end(), blinder.begin(), blinder.end());
-}
-
 void CConfidentialValue::SetToBlinder(const uint256& blinder)
 {
     vchCommitment.reserve(nCommittedSize);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -103,7 +103,7 @@ public:
     }
 };
 
-/** A 33-byte commitment to a blinded asset, a 32-byte naked blinding value, or an explicit asset NUMS identifier */
+/** A 33-byte commitment to a blinded asset or an explicit asset NUMS identifier */
 class CConfidentialAsset : public CConfidentialCommitment<33, 10, 11, 12>
 {
 public:

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -109,7 +109,6 @@ class CConfidentialAsset : public CConfidentialCommitment<33, 10, 11, 12>
 public:
     CConfidentialAsset() { SetNull(); }
     CConfidentialAsset(CAsset asset) { SetToAsset(asset); }
-    CConfidentialAsset(uint256 blinder) { SetToBlinder(blinder); }
 
     /* An explicit asset identifier is a 256-bit nothing-up-my-sleeve number
      * that used as auxiliary input to the Pedersen commitment setup to create
@@ -119,13 +118,7 @@ public:
         assert(IsExplicit());
         return *reinterpret_cast<const CAsset*>(&vchCommitment[1]);
     }
-    const uint256& GetBlinder() const
-    {
-        assert(IsBlinder());
-        return *reinterpret_cast<const uint256*>(&vchCommitment[1]);
-    }
     void SetToAsset(const CAsset& asset);
-    void SetToBlinder(const uint256& blinder);
 
 };
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -898,10 +898,6 @@ bool VerifyAmounts(const CCoinsViewCache& cache, const CTransaction& tx, std::ve
         } else if (asset.IsCommitment()) {
             if (secp256k1_generator_parse(secp256k1_ctx_verify_amounts, &gen, &asset.vchCommitment[0]) != 1)
                 return false;
-        } else if (asset.IsBlinder()) {
-            if (secp256k1_generator_generate_blinded(secp256k1_ctx_verify_amounts, &gen, zero, asset.GetBlinder().begin()) != 1) {
-                return false;
-            }
         } else {
             return false;
         }
@@ -976,7 +972,7 @@ bool VerifyAmounts(const CCoinsViewCache& cache, const CTransaction& tx, std::ve
         const CConfidentialAsset& asset = tx.vout[i].nAsset;
         const CTxOutWitness* ptxoutwit = tx.wit.vtxoutwit.size() <= i? NULL: &tx.wit.vtxoutwit[i];
         //No need for surjective proof
-        if (asset.IsExplicit() || asset.IsBlinder()) {
+        if (asset.IsExplicit()) {
             if (ptxoutwit && !ptxoutwit->vchSurjectionproof.empty()) {
                 return false;
             }


### PR DESCRIPTION
A blinded asset commitment `A'` consists of an "asset ID" `A` plus some blinding factor times a generator `rG`. Written out, we have `A + rG =: A'`

A blinded value commitment `C` consists of a value `v` times an asset commitment `A'` plus some other blinding factor `r'G`. Written out, we have `C := vA' + r'G`

Since the serialization assumes that the value `v` in a naked blinder is always zero (I can't think of a case where it wouldn't be), the `vA'` term will always drop out above, and so there is no reason to include code for a blinder in CConfidentialAsset