### PR TITLE
fix TxToJSON(), add IsValid() and GetAmount() support for naked blinder

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -12,7 +12,7 @@
 
 void CConfidentialAsset::SetToAsset(const CAsset& asset)
 {
-	vchCommitment.clear();
+    vchCommitment.clear();
     vchCommitment.reserve(nExplicitSize);
     vchCommitment.push_back(1);
     vchCommitment.insert(vchCommitment.end(), asset.begin(), asset.end());
@@ -20,7 +20,7 @@ void CConfidentialAsset::SetToAsset(const CAsset& asset)
 
 void CConfidentialValue::SetToBlinder(const uint256& blinder)
 {
-	vchCommitment.clear();
+    vchCommitment.clear();
     vchCommitment.reserve(nCommittedSize);
     vchCommitment.push_back(13);
     vchCommitment.insert(vchCommitment.end(), blinder.begin(), blinder.end());


### PR DESCRIPTION
couple quick fixes here that came up when using this for MW. added support for `IsValid()` and `GetAmount()` where the explicit amount of a naked blinder is assumed to always be zero.

also, the code had no specific execution pathway for a naked blinder in the `TxToJSON()` function (i noticed this when attempting to run `decoderuntransaction`). Instead of failing the `IsExplicit()` check and defaulting to the `else` statement, I changed it to explicitly check `IsCommitment()` and `IsBlinder()` so that they can be handled on their own. The `assert(0)` at the end should never be reached and will serve as a fail fast reminder in case anyone adds more output types or something. This should probably be added to the main elements code but I presume naked blinder support will be merged at some point so i'll keep it in this PR.

Also, a test should be added at some point that creates a tx with a naked blinder. If not, my (eventual) MW PR will certainly have txs that have this and will be tested against.